### PR TITLE
v1.1.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Phil Vessey and Contributors
+Copyright (c) 2021 Phil Vessey and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/TransXChange.Common/Helpers/GtfsHelpers.cs
+++ b/TransXChange.Common/Helpers/GtfsHelpers.cs
@@ -7,9 +7,9 @@ using System.Linq;
 using TransXChange.Common.Extensions;
 using TransXChange.Common.Models;
 
-namespace TransXChange.Common
+namespace TransXChange.Common.Helpers
 {
-    public static class Gtfs
+    public static class GtfsHelpers
     {
         private static Dictionary<string, GTFSAgency> _agencies = new Dictionary<string, GTFSAgency>();
         private static Dictionary<string, GTFSCalendar> _calendars = new Dictionary<string, GTFSCalendar>();

--- a/TransXChange.Common/Helpers/GtfsHelpers.cs
+++ b/TransXChange.Common/Helpers/GtfsHelpers.cs
@@ -9,17 +9,17 @@ using TransXChange.Common.Models;
 
 namespace TransXChange.Common.Helpers
 {
-    public static class GtfsHelpers
+    public class GtfsHelpers
     {
-        private static Dictionary<string, GTFSAgency> _agencies = new Dictionary<string, GTFSAgency>();
-        private static Dictionary<string, GTFSCalendar> _calendars = new Dictionary<string, GTFSCalendar>();
-        private static Dictionary<string, GTFSCalendarDate> _calendarDates = new Dictionary<string, GTFSCalendarDate>();
-        private static Dictionary<string, GTFSRoute> _routes = new Dictionary<string, GTFSRoute>();
-        private static Dictionary<string, GTFSStop> _stops = new Dictionary<string, GTFSStop>();
-        private static Dictionary<string, GTFSStopTime> _stopTimes = new Dictionary<string, GTFSStopTime>();
-        private static Dictionary<string, GTFSTrip> _trips = new Dictionary<string, GTFSTrip>();
+        private Dictionary<string, GTFSAgency> _agencies = new Dictionary<string, GTFSAgency>();
+        private Dictionary<string, GTFSCalendar> _calendars = new Dictionary<string, GTFSCalendar>();
+        private Dictionary<string, GTFSCalendarDate> _calendarDates = new Dictionary<string, GTFSCalendarDate>();
+        private Dictionary<string, GTFSRoute> _routes = new Dictionary<string, GTFSRoute>();
+        private Dictionary<string, GTFSStop> _stops = new Dictionary<string, GTFSStop>();
+        private Dictionary<string, GTFSStopTime> _stopTimes = new Dictionary<string, GTFSStopTime>();
+        private Dictionary<string, GTFSTrip> _trips = new Dictionary<string, GTFSTrip>();
 
-        public static void WriteAgency(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteAgency(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareAgency(originals, duplicates);
 
@@ -36,7 +36,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        public static void WriteCalendar(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteCalendar(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareCalendar(originals, duplicates);
 
@@ -53,7 +53,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        public static void WriteCalendarDates(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteCalendarDates(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareCalendarDates(originals, duplicates);
 
@@ -70,7 +70,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        public static void WriteRoutes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteRoutes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareRoutes(originals, duplicates);
 
@@ -87,7 +87,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        public static void WriteStops(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteStops(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareStops(originals, duplicates);
 
@@ -104,7 +104,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        public static void WriteStopTimes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteStopTimes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareStopTimes(originals, duplicates);
 
@@ -121,7 +121,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        public static void WriteTrips(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
+        public void WriteTrips(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates, string path)
         {
             PrepareTrips(originals, duplicates);
 
@@ -138,7 +138,7 @@ namespace TransXChange.Common.Helpers
             }
         }
 
-        private static void PrepareAgency(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareAgency(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {
@@ -165,7 +165,7 @@ namespace TransXChange.Common.Helpers
             _agencies = _agencies.OrderBy(a => a.Value.AgencyId).ToDictionary(a => a.Key, a => a.Value);
         }
 
-        private static void PrepareCalendar(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareCalendar(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {
@@ -194,7 +194,7 @@ namespace TransXChange.Common.Helpers
             _calendars = _calendars.OrderBy(c => c.Value.ServiceId).ToDictionary(c => c.Key, c => c.Value);
         }
 
-        private static void PrepareCalendarDates(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareCalendarDates(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {
@@ -236,7 +236,7 @@ namespace TransXChange.Common.Helpers
             _calendarDates = _calendarDates.OrderBy(c => c.Value.ServiceId).ToDictionary(c => c.Key, c => c.Value);
         }
 
-        private static void PrepareRoutes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareRoutes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {
@@ -260,7 +260,7 @@ namespace TransXChange.Common.Helpers
             _routes = _routes.OrderBy(r => r.Value.RouteId).ToDictionary(r => r.Key, r => r.Value);
         }
 
-        private static void PrepareStops(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareStops(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {
@@ -289,7 +289,7 @@ namespace TransXChange.Common.Helpers
             _stops = _stops.OrderBy(s => s.Value.StopId).ToDictionary(s => s.Key, s => s.Value);
         }
 
-        private static void PrepareStopTimes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareStopTimes(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {
@@ -350,7 +350,7 @@ namespace TransXChange.Common.Helpers
             _stopTimes = _stopTimes.OrderBy(s => s.Value.TripId).ToDictionary(s => s.Key, s => s.Value);
         }
 
-        private static void PrepareTrips(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
+        private void PrepareTrips(Dictionary<string, TXCSchedule> originals, Dictionary<string, TXCSchedule> duplicates)
         {
             foreach (TXCSchedule schedule in originals.Values)
             {

--- a/TransXChange.Common/Helpers/NaptanHelpers.cs
+++ b/TransXChange.Common/Helpers/NaptanHelpers.cs
@@ -7,9 +7,9 @@ using TransXChange.Common.Models;
 
 namespace TransXChange.Common.Helpers
 {
-    public static class NaptanHelpers
+    public class NaptanHelpers
     {
-        public static Dictionary<string, NAPTANStop> Read(string path)
+        public Dictionary<string, NAPTANStop> Read(string path)
         {
             Dictionary<string, NAPTANStop> dictionary = new Dictionary<string, NAPTANStop>();
 

--- a/TransXChange.Common/Helpers/NaptanHelpers.cs
+++ b/TransXChange.Common/Helpers/NaptanHelpers.cs
@@ -5,9 +5,9 @@ using System.IO;
 using System.IO.Compression;
 using TransXChange.Common.Models;
 
-namespace TransXChange.Common
+namespace TransXChange.Common.Helpers
 {
-    public static class Naptan
+    public static class NaptanHelpers
     {
         public static Dictionary<string, NAPTANStop> Read(string path)
         {

--- a/TransXChange.Common/Helpers/TravelineHelpers.cs
+++ b/TransXChange.Common/Helpers/TravelineHelpers.cs
@@ -3444,9 +3444,53 @@ namespace TransXChange.Common.Helpers
                 {
                     for (int i = 1; i <= schedule.Calendar.RunningDates.Count; i++)
                     {
-                        IEnumerable<TXCSchedule> duplicates = originals.Values.Where(s => s.Calendar.RunningDates.Contains(schedule.Calendar.RunningDates[i - 1]) && s.Id != schedule.Id);
+                        IEnumerable<TXCSchedule> runningDateDuplicates = originals.Values.Where(s => s.Calendar.RunningDates.Contains(schedule.Calendar.RunningDates[i - 1]) && s.Id != schedule.Id);
 
-                        foreach (TXCSchedule duplicate in duplicates)
+                        foreach (TXCSchedule duplicate in runningDateDuplicates)
+                        {
+                            if (!dictionary.ContainsKey(duplicate.Id))
+                            {
+                                if (schedule.Stops.FirstOrDefault().ATCOCode == duplicate.Stops.FirstOrDefault().ATCOCode && schedule.Stops.FirstOrDefault().DepartureTime == duplicate.Stops.FirstOrDefault().DepartureTime)
+                                {
+                                    if (schedule.Stops.LastOrDefault().ATCOCode == duplicate.Stops.LastOrDefault().ATCOCode && schedule.Stops.LastOrDefault().ArrivalTime == duplicate.Stops.LastOrDefault().ArrivalTime)
+                                    {
+                                        if (schedule.Line == duplicate.Line)
+                                        {
+                                            if (!dictionary.ContainsKey(duplicate.Id))
+                                            {
+                                                dictionary.Add(duplicate.Id, duplicate);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        IEnumerable<TXCSchedule> supplementRunningDateDuplicates = originals.Values.Where(s => s.Calendar.SupplementRunningDates.Contains(schedule.Calendar.RunningDates[i - 1]) && s.Id != schedule.Id);
+
+                        foreach (TXCSchedule duplicate in supplementRunningDateDuplicates)
+                        {
+                            if (!dictionary.ContainsKey(duplicate.Id))
+                            {
+                                if (schedule.Stops.FirstOrDefault().ATCOCode == duplicate.Stops.FirstOrDefault().ATCOCode && schedule.Stops.FirstOrDefault().DepartureTime == duplicate.Stops.FirstOrDefault().DepartureTime)
+                                {
+                                    if (schedule.Stops.LastOrDefault().ATCOCode == duplicate.Stops.LastOrDefault().ATCOCode && schedule.Stops.LastOrDefault().ArrivalTime == duplicate.Stops.LastOrDefault().ArrivalTime)
+                                    {
+                                        if (schedule.Line == duplicate.Line)
+                                        {
+                                            if (!dictionary.ContainsKey(duplicate.Id))
+                                            {
+                                                dictionary.Add(duplicate.Id, duplicate);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        IEnumerable<TXCSchedule> supplementNonRunningDateDuplicates = originals.Values.Where(s => s.Calendar.SupplementNonRunningDates.Contains(schedule.Calendar.RunningDates[i - 1]) && s.Id != schedule.Id);
+
+                        foreach (TXCSchedule duplicate in supplementNonRunningDateDuplicates)
                         {
                             if (!dictionary.ContainsKey(duplicate.Id))
                             {
@@ -3466,12 +3510,59 @@ namespace TransXChange.Common.Helpers
                             }
                         }
                     }
+                }
 
+                if (!dictionary.ContainsKey(schedule.Id))
+                {
                     for (int i = 1; i <= schedule.Calendar.SupplementRunningDates.Count; i++)
                     {
-                        IEnumerable<TXCSchedule> duplicates = originals.Values.Where(s => s.Calendar.SupplementRunningDates.Contains(schedule.Calendar.RunningDates[i - 1]) && s.Id != schedule.Id);
+                        IEnumerable<TXCSchedule> runningDateDuplicates = originals.Values.Where(s => s.Calendar.RunningDates.Contains(schedule.Calendar.SupplementRunningDates[i - 1]) && s.Id != schedule.Id);
 
-                        foreach (TXCSchedule duplicate in duplicates)
+                        foreach (TXCSchedule duplicate in runningDateDuplicates)
+                        {
+                            if (!dictionary.ContainsKey(duplicate.Id))
+                            {
+                                if (schedule.Stops.FirstOrDefault().ATCOCode == duplicate.Stops.FirstOrDefault().ATCOCode && schedule.Stops.FirstOrDefault().DepartureTime == duplicate.Stops.FirstOrDefault().DepartureTime)
+                                {
+                                    if (schedule.Stops.LastOrDefault().ATCOCode == duplicate.Stops.LastOrDefault().ATCOCode && schedule.Stops.LastOrDefault().ArrivalTime == duplicate.Stops.LastOrDefault().ArrivalTime)
+                                    {
+                                        if (schedule.Line == duplicate.Line)
+                                        {
+                                            if (!dictionary.ContainsKey(duplicate.Id))
+                                            {
+                                                dictionary.Add(duplicate.Id, duplicate);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        IEnumerable<TXCSchedule> supplementRunningDateDuplicates = originals.Values.Where(s => s.Calendar.SupplementRunningDates.Contains(schedule.Calendar.SupplementRunningDates[i - 1]) && s.Id != schedule.Id);
+
+                        foreach (TXCSchedule duplicate in supplementRunningDateDuplicates)
+                        {
+                            if (!dictionary.ContainsKey(duplicate.Id))
+                            {
+                                if (schedule.Stops.FirstOrDefault().ATCOCode == duplicate.Stops.FirstOrDefault().ATCOCode && schedule.Stops.FirstOrDefault().DepartureTime == duplicate.Stops.FirstOrDefault().DepartureTime)
+                                {
+                                    if (schedule.Stops.LastOrDefault().ATCOCode == duplicate.Stops.LastOrDefault().ATCOCode && schedule.Stops.LastOrDefault().ArrivalTime == duplicate.Stops.LastOrDefault().ArrivalTime)
+                                    {
+                                        if (schedule.Line == duplicate.Line)
+                                        {
+                                            if (!dictionary.ContainsKey(duplicate.Id))
+                                            {
+                                                dictionary.Add(duplicate.Id, duplicate);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        IEnumerable<TXCSchedule> supplementNonRunningDateDuplicates = originals.Values.Where(s => s.Calendar.SupplementNonRunningDates.Contains(schedule.Calendar.SupplementRunningDates[i - 1]) && s.Id != schedule.Id);
+
+                        foreach (TXCSchedule duplicate in supplementNonRunningDateDuplicates)
                         {
                             if (!dictionary.ContainsKey(duplicate.Id))
                             {
@@ -3491,12 +3582,59 @@ namespace TransXChange.Common.Helpers
                             }
                         }
                     }
+                }
 
+                if (!dictionary.ContainsKey(schedule.Id))
+                {
                     for (int i = 1; i <= schedule.Calendar.SupplementNonRunningDates.Count; i++)
                     {
-                        IEnumerable<TXCSchedule> duplicates = originals.Values.Where(s => s.Calendar.SupplementNonRunningDates.Contains(schedule.Calendar.RunningDates[i - 1]) && s.Id != schedule.Id);
+                        IEnumerable<TXCSchedule> runningDateDuplicates = originals.Values.Where(s => s.Calendar.RunningDates.Contains(schedule.Calendar.SupplementNonRunningDates[i - 1]) && s.Id != schedule.Id);
 
-                        foreach (TXCSchedule duplicate in duplicates)
+                        foreach (TXCSchedule duplicate in runningDateDuplicates)
+                        {
+                            if (!dictionary.ContainsKey(duplicate.Id))
+                            {
+                                if (schedule.Stops.FirstOrDefault().ATCOCode == duplicate.Stops.FirstOrDefault().ATCOCode && schedule.Stops.FirstOrDefault().DepartureTime == duplicate.Stops.FirstOrDefault().DepartureTime)
+                                {
+                                    if (schedule.Stops.LastOrDefault().ATCOCode == duplicate.Stops.LastOrDefault().ATCOCode && schedule.Stops.LastOrDefault().ArrivalTime == duplicate.Stops.LastOrDefault().ArrivalTime)
+                                    {
+                                        if (schedule.Line == duplicate.Line)
+                                        {
+                                            if (!dictionary.ContainsKey(duplicate.Id))
+                                            {
+                                                dictionary.Add(duplicate.Id, duplicate);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        IEnumerable<TXCSchedule> supplementRunningDateDuplicates = originals.Values.Where(s => s.Calendar.SupplementRunningDates.Contains(schedule.Calendar.SupplementNonRunningDates[i - 1]) && s.Id != schedule.Id);
+
+                        foreach (TXCSchedule duplicate in supplementRunningDateDuplicates)
+                        {
+                            if (!dictionary.ContainsKey(duplicate.Id))
+                            {
+                                if (schedule.Stops.FirstOrDefault().ATCOCode == duplicate.Stops.FirstOrDefault().ATCOCode && schedule.Stops.FirstOrDefault().DepartureTime == duplicate.Stops.FirstOrDefault().DepartureTime)
+                                {
+                                    if (schedule.Stops.LastOrDefault().ATCOCode == duplicate.Stops.LastOrDefault().ATCOCode && schedule.Stops.LastOrDefault().ArrivalTime == duplicate.Stops.LastOrDefault().ArrivalTime)
+                                    {
+                                        if (schedule.Line == duplicate.Line)
+                                        {
+                                            if (!dictionary.ContainsKey(duplicate.Id))
+                                            {
+                                                dictionary.Add(duplicate.Id, duplicate);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        IEnumerable<TXCSchedule> supplementNonRunningDateDuplicates = originals.Values.Where(s => s.Calendar.SupplementNonRunningDates.Contains(schedule.Calendar.SupplementNonRunningDates[i - 1]) && s.Id != schedule.Id);
+
+                        foreach (TXCSchedule duplicate in supplementNonRunningDateDuplicates)
                         {
                             if (!dictionary.ContainsKey(duplicate.Id))
                             {

--- a/TransXChange.Common/Helpers/TravelineHelpers.cs
+++ b/TransXChange.Common/Helpers/TravelineHelpers.cs
@@ -10,9 +10,9 @@ using TransXChange.Common.Extensions;
 using TransXChange.Common.Models;
 using TransXChange.Common.Utils;
 
-namespace TransXChange.Common
+namespace TransXChange.Common.Helpers
 {
-    public static class Traveline
+    public static class TravelineHelpers
     {
         public static Dictionary<string, TXCSchedule> ReadEngland(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
         {

--- a/TransXChange.Common/Helpers/TravelineHelpers.cs
+++ b/TransXChange.Common/Helpers/TravelineHelpers.cs
@@ -12,9 +12,9 @@ using TransXChange.Common.Utils;
 
 namespace TransXChange.Common.Helpers
 {
-    public static class TravelineHelpers
+    public class TravelineHelpers
     {
-        public static Dictionary<string, TXCSchedule> ReadEngland(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
+        public Dictionary<string, TXCSchedule> ReadEngland(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
         {
             Dictionary<string, TXCSchedule> dictionary = new Dictionary<string, TXCSchedule>();
 
@@ -1114,7 +1114,7 @@ namespace TransXChange.Common.Helpers
             return dictionary;
         }
 
-        public static Dictionary<string, TXCSchedule> ReadScotland(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
+        public Dictionary<string, TXCSchedule> ReadScotland(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
         {
             Dictionary<string, TXCSchedule> dictionary = new Dictionary<string, TXCSchedule>();
 
@@ -2334,7 +2334,7 @@ namespace TransXChange.Common.Helpers
             return dictionary;
         }
 
-        public static Dictionary<string, TXCSchedule> ReadWales(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
+        public Dictionary<string, TXCSchedule> ReadWales(Dictionary<string, NAPTANStop> stops, string path, string mode, IEnumerable<string> filters, double days)
         {
             Dictionary<string, TXCSchedule> dictionary = new Dictionary<string, TXCSchedule>();
 
@@ -3434,7 +3434,7 @@ namespace TransXChange.Common.Helpers
             return dictionary;
         }
 
-        public static Dictionary<string, TXCSchedule> ScanDuplicate(Dictionary<string, TXCSchedule> originals)
+        public Dictionary<string, TXCSchedule> ScanDuplicate(Dictionary<string, TXCSchedule> originals)
         {
             Dictionary<string, TXCSchedule> dictionary = new Dictionary<string, TXCSchedule>();
 

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="21.3.1" />
+    <PackageReference Include="CsvHelper" Version="22.1.0" />
     <PackageReference Include="Nager.Date" Version="1.27.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="26.0.0" />
+    <PackageReference Include="CsvHelper" Version="26.0.1" />
     <PackageReference Include="Nager.Date" Version="1.28.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="21.1.1" />
+    <PackageReference Include="CsvHelper" Version="21.2.1" />
     <PackageReference Include="Nager.Date" Version="1.27.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="21.2.1" />
+    <PackageReference Include="CsvHelper" Version="21.3.0" />
     <PackageReference Include="Nager.Date" Version="1.27.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="CsvHelper" Version="26.0.1" />
-    <PackageReference Include="Nager.Date" Version="1.28.1" />
+    <PackageReference Include="Nager.Date" Version="1.28.2" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="15.0.5" />
+    <PackageReference Include="CsvHelper" Version="15.0.6" />
     <PackageReference Include="Nager.Date" Version="1.26.3" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="21.3.0" />
+    <PackageReference Include="CsvHelper" Version="21.3.1" />
     <PackageReference Include="Nager.Date" Version="1.27.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="21.0.0" />
+    <PackageReference Include="CsvHelper" Version="21.0.5" />
     <PackageReference Include="Nager.Date" Version="1.27.0" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="23.0.0" />
-    <PackageReference Include="Nager.Date" Version="1.28.0" />
+    <PackageReference Include="CsvHelper" Version="24.0.0" />
+    <PackageReference Include="Nager.Date" Version="1.28.1" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="Nager.Date" Version="1.26.2" />
+    <PackageReference Include="Nager.Date" Version="1.26.3" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="17.0.1" />
+    <PackageReference Include="CsvHelper" Version="18.0.0" />
     <PackageReference Include="Nager.Date" Version="1.26.6" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="22.1.0" />
-    <PackageReference Include="Nager.Date" Version="1.27.1" />
+    <PackageReference Include="CsvHelper" Version="22.1.1" />
+    <PackageReference Include="Nager.Date" Version="1.28.0" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="21.0.5" />
-    <PackageReference Include="Nager.Date" Version="1.27.0" />
+    <PackageReference Include="CsvHelper" Version="21.1.1" />
+    <PackageReference Include="Nager.Date" Version="1.27.1" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="17.0.0" />
+    <PackageReference Include="CsvHelper" Version="17.0.1" />
     <PackageReference Include="Nager.Date" Version="1.26.6" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="CsvHelper" Version="19.0.0" />
-    <PackageReference Include="Nager.Date" Version="1.26.7" />
+    <PackageReference Include="Nager.Date" Version="1.27.0" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="22.1.1" />
+    <PackageReference Include="CsvHelper" Version="22.1.2" />
     <PackageReference Include="Nager.Date" Version="1.28.0" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="26.0.1" />
+    <PackageReference Include="CsvHelper" Version="26.1.0" />
     <PackageReference Include="Nager.Date" Version="1.28.2" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="25.0.0" />
+    <PackageReference Include="CsvHelper" Version="26.0.0" />
     <PackageReference Include="Nager.Date" Version="1.28.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="15.0.6" />
-    <PackageReference Include="Nager.Date" Version="1.26.3" />
+    <PackageReference Include="CsvHelper" Version="15.0.10" />
+    <PackageReference Include="Nager.Date" Version="1.26.4" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="16.1.0" />
+    <PackageReference Include="CsvHelper" Version="16.2.0" />
     <PackageReference Include="Nager.Date" Version="1.26.6" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="24.0.1" />
+    <PackageReference Include="CsvHelper" Version="25.0.0" />
     <PackageReference Include="Nager.Date" Version="1.28.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="15.0.10" />
-    <PackageReference Include="Nager.Date" Version="1.26.4" />
+    <PackageReference Include="CsvHelper" Version="16.1.0" />
+    <PackageReference Include="Nager.Date" Version="1.26.5" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="19.0.0" />
+    <PackageReference Include="CsvHelper" Version="21.0.0" />
     <PackageReference Include="Nager.Date" Version="1.27.0" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="22.1.2" />
+    <PackageReference Include="CsvHelper" Version="23.0.0" />
     <PackageReference Include="Nager.Date" Version="1.28.0" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="18.0.0" />
-    <PackageReference Include="Nager.Date" Version="1.26.6" />
+    <PackageReference Include="CsvHelper" Version="19.0.0" />
+    <PackageReference Include="Nager.Date" Version="1.26.7" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="16.2.0" />
+    <PackageReference Include="CsvHelper" Version="17.0.0" />
     <PackageReference Include="Nager.Date" Version="1.26.6" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="CsvHelper" Version="24.0.0" />
+    <PackageReference Include="CsvHelper" Version="24.0.1" />
     <PackageReference Include="Nager.Date" Version="1.28.1" />
   </ItemGroup>
     

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -12,6 +12,7 @@
     
   <ItemGroup>
     <Folder Include="Extensions\" />
+    <Folder Include="Helpers\" />
     <Folder Include="Models\" />
     <Folder Include="Utils\" />
   </ItemGroup>

--- a/TransXChange.Common/TransXChange.Common.csproj
+++ b/TransXChange.Common/TransXChange.Common.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="CsvHelper" Version="16.1.0" />
-    <PackageReference Include="Nager.Date" Version="1.26.5" />
+    <PackageReference Include="Nager.Date" Version="1.26.6" />
   </ItemGroup>
     
   <ItemGroup>

--- a/TransXChange.Common/Traveline.cs
+++ b/TransXChange.Common/Traveline.cs
@@ -58,6 +58,12 @@ namespace TransXChange.Common
                                 }
 
                                 TXCXmlJourneyPattern journeyPattern = xml.Services.Service.StandardService.JourneyPattern.Where(p => p.Id == journeyPatternReference).FirstOrDefault();
+
+                                if (journeyPattern == null)
+                                {
+                                    journeyPattern = xml.Services.Service.StandardService.JourneyPattern.FirstOrDefault();
+                                }
+
                                 TXCXmlOperatingProfile operatingProfile = vehicleJourney.OperatingProfile;
 
                                 if (operatingProfile == null)
@@ -598,6 +604,12 @@ namespace TransXChange.Common
                                 }
 
                                 TXCXmlJourneyPattern journeyPattern = xml.Services.Service.StandardService.JourneyPattern.Where(p => p.Id == journeyPatternReference).FirstOrDefault();
+
+                                if (journeyPattern == null)
+                                {
+                                    journeyPattern = xml.Services.Service.StandardService.JourneyPattern.FirstOrDefault();
+                                }
+
                                 TXCXmlOperatingProfile operatingProfile = vehicleJourney.OperatingProfile;
 
                                 if (operatingProfile == null)
@@ -1146,6 +1158,12 @@ namespace TransXChange.Common
                                 }
 
                                 TXCXmlJourneyPattern journeyPattern = xml.Services.Service.StandardService.JourneyPattern.Where(p => p.Id == journeyPatternReference).FirstOrDefault();
+
+                                if (journeyPattern == null)
+                                {
+                                    journeyPattern = xml.Services.Service.StandardService.JourneyPattern.FirstOrDefault();
+                                }
+
                                 TXCXmlOperatingProfile operatingProfile = vehicleJourney.OperatingProfile;
 
                                 if (operatingProfile == null)
@@ -1746,6 +1764,12 @@ namespace TransXChange.Common
                                 }
 
                                 TXCXmlJourneyPattern journeyPattern = xml.Services.Service.StandardService.JourneyPattern.Where(p => p.Id == journeyPatternReference).FirstOrDefault();
+
+                                if (journeyPattern == null)
+                                {
+                                    journeyPattern = xml.Services.Service.StandardService.JourneyPattern.FirstOrDefault();
+                                }
+
                                 TXCXmlOperatingProfile operatingProfile = vehicleJourney.OperatingProfile;
 
                                 if (operatingProfile == null)
@@ -2354,6 +2378,12 @@ namespace TransXChange.Common
                                 }
 
                                 TXCXmlJourneyPattern journeyPattern = xml.Services.Service.StandardService.JourneyPattern.Where(p => p.Id == journeyPatternReference).FirstOrDefault();
+
+                                if (journeyPattern == null)
+                                {
+                                    journeyPattern = xml.Services.Service.StandardService.JourneyPattern.FirstOrDefault();
+                                }
+
                                 TXCXmlOperatingProfile operatingProfile = vehicleJourney.OperatingProfile;
 
                                 if (operatingProfile == null)
@@ -2894,6 +2924,12 @@ namespace TransXChange.Common
                                 }
 
                                 TXCXmlJourneyPattern journeyPattern = xml.Services.Service.StandardService.JourneyPattern.Where(p => p.Id == journeyPatternReference).FirstOrDefault();
+
+                                if (journeyPattern == null)
+                                {
+                                    journeyPattern = xml.Services.Service.StandardService.JourneyPattern.FirstOrDefault();
+                                }
+
                                 TXCXmlOperatingProfile operatingProfile = vehicleJourney.OperatingProfile;
 
                                 if (operatingProfile == null)

--- a/TransXChange.Common/Traveline.cs
+++ b/TransXChange.Common/Traveline.cs
@@ -45,6 +45,11 @@ namespace TransXChange.Common
                                     continue;
                                 }
 
+                                if (startDate > endDate || endDate < startDate)
+                                {
+                                    continue;
+                                }
+
                                 string journeyPatternReference = vehicleJourney.JourneyPatternRef;
 
                                 if (journeyPatternReference == null)
@@ -576,6 +581,11 @@ namespace TransXChange.Common
                                 DateTime? endDate = DateTimeUtils.GetEndDate(xml.Services.Service.OperatingPeriod.EndDate.ToDateTime(), now, days);
 
                                 if (startDate == null || endDate == null)
+                                {
+                                    continue;
+                                }
+
+                                if (startDate > endDate || endDate < startDate)
                                 {
                                     continue;
                                 }
@@ -1119,6 +1129,11 @@ namespace TransXChange.Common
                                 DateTime? endDate = DateTimeUtils.GetEndDate(xml.Services.Service.OperatingPeriod.EndDate.ToDateTime(), now, days);
 
                                 if (startDate == null || endDate == null)
+                                {
+                                    continue;
+                                }
+
+                                if (startDate > endDate || endDate < startDate)
                                 {
                                     continue;
                                 }
@@ -1714,6 +1729,11 @@ namespace TransXChange.Common
                                 DateTime? endDate = DateTimeUtils.GetEndDate(xml.Services.Service.OperatingPeriod.EndDate.ToDateTime(), now, days);
 
                                 if (startDate == null || endDate == null)
+                                {
+                                    continue;
+                                }
+
+                                if (startDate > endDate || endDate < startDate)
                                 {
                                     continue;
                                 }
@@ -2321,6 +2341,11 @@ namespace TransXChange.Common
                                     continue;
                                 }
 
+                                if (startDate > endDate || endDate < startDate)
+                                {
+                                    continue;
+                                }
+
                                 string journeyPatternReference = vehicleJourney.JourneyPatternRef;
 
                                 if (journeyPatternReference == null)
@@ -2852,6 +2877,11 @@ namespace TransXChange.Common
                                 DateTime? endDate = DateTimeUtils.GetEndDate(xml.Services.Service.OperatingPeriod.EndDate.ToDateTime(), now, days);
 
                                 if (startDate == null || endDate == null)
+                                {
+                                    continue;
+                                }
+
+                                if (startDate > endDate || endDate < startDate)
                                 {
                                     continue;
                                 }

--- a/TransXChange.Common/Traveline.cs
+++ b/TransXChange.Common/Traveline.cs
@@ -402,10 +402,10 @@ namespace TransXChange.Common
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
                                 TimeSpan? departureTime = vehicleJourney.DepartureTime.ToTimeSpan();
 
-                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
-                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection.JourneyPatternTimingLink;
+                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections?.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
+                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection?.JourneyPatternTimingLink;
 
-                                for (int i = 1; i <= patternTimings.Count; i++)
+                                for (int i = 1; i <= patternTimings?.Count; i++)
                                 {
                                     TXCStop stop = new TXCStop();
 
@@ -937,10 +937,10 @@ namespace TransXChange.Common
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
                                 TimeSpan? departureTime = vehicleJourney.DepartureTime.ToTimeSpan();
 
-                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
-                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection.JourneyPatternTimingLink;
+                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections?.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
+                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection?.JourneyPatternTimingLink;
 
-                                for (int i = 1; i <= patternTimings.Count; i++)
+                                for (int i = 1; i <= patternTimings?.Count; i++)
                                 {
                                     TXCStop stop = new TXCStop();
 
@@ -1540,10 +1540,10 @@ namespace TransXChange.Common
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
                                 TimeSpan? departureTime = vehicleJourney.DepartureTime.ToTimeSpan();
 
-                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
-                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection.JourneyPatternTimingLink;
+                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections?.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
+                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection?.JourneyPatternTimingLink;
 
-                                for (int i = 1; i <= patternTimings.Count; i++)
+                                for (int i = 1; i <= patternTimings?.Count; i++)
                                 {
                                     TXCStop stop = new TXCStop();
 
@@ -2135,10 +2135,10 @@ namespace TransXChange.Common
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
                                 TimeSpan? departureTime = vehicleJourney.DepartureTime.ToTimeSpan();
 
-                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
-                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection.JourneyPatternTimingLink;
+                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections?.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
+                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection?.JourneyPatternTimingLink;
 
-                                for (int i = 1; i <= patternTimings.Count; i++)
+                                for (int i = 1; i <= patternTimings?.Count; i++)
                                 {
                                     TXCStop stop = new TXCStop();
 
@@ -2678,10 +2678,10 @@ namespace TransXChange.Common
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
                                 TimeSpan? departureTime = vehicleJourney.DepartureTime.ToTimeSpan();
 
-                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
-                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection.JourneyPatternTimingLink;
+                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections?.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
+                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection?.JourneyPatternTimingLink;
 
-                                for (int i = 1; i <= patternTimings.Count; i++)
+                                for (int i = 1; i <= patternTimings?.Count; i++)
                                 {
                                     TXCStop stop = new TXCStop();
 
@@ -3213,10 +3213,10 @@ namespace TransXChange.Common
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
                                 TimeSpan? departureTime = vehicleJourney.DepartureTime.ToTimeSpan();
 
-                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
-                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection.JourneyPatternTimingLink;
+                                TXCXmlJourneyPatternSection patternSection = xml.JourneyPatternSections?.JourneyPatternSection.Where(s => s.Id == journeyPattern.JourneyPatternSectionRefs).FirstOrDefault();
+                                List<TXCXmlJourneyPatternTimingLink> patternTimings = patternSection?.JourneyPatternTimingLink;
 
-                                for (int i = 1; i <= patternTimings.Count; i++)
+                                for (int i = 1; i <= patternTimings?.Count; i++)
                                 {
                                     TXCStop stop = new TXCStop();
 

--- a/TransXChange.Common/Traveline.cs
+++ b/TransXChange.Common/Traveline.cs
@@ -394,9 +394,9 @@ namespace TransXChange.Common
                                     }
                                 }
 
-                                calendar.RunningDates = calendar.RunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.OrderBy(d => d).ToList();
+                                calendar.RunningDates = calendar.RunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.Distinct().OrderBy(d => d).ToList();
 
                                 TXCSchedule schedule = ScheduleUtils.Build(xml.Operators.Operator, xml.Services.Service, journeyPattern, calendar);
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
@@ -929,9 +929,9 @@ namespace TransXChange.Common
                                     }
                                 }
 
-                                calendar.RunningDates = calendar.RunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.OrderBy(d => d).ToList();
+                                calendar.RunningDates = calendar.RunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.Distinct().OrderBy(d => d).ToList();
 
                                 TXCSchedule schedule = ScheduleUtils.Build(xml.Operators.Operator, xml.Services.Service, journeyPattern, calendar);
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
@@ -1532,9 +1532,9 @@ namespace TransXChange.Common
                                     }
                                 }
 
-                                calendar.RunningDates = calendar.RunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.OrderBy(d => d).ToList();
+                                calendar.RunningDates = calendar.RunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.Distinct().OrderBy(d => d).ToList();
 
                                 TXCSchedule schedule = ScheduleUtils.Build(xml.Operators.Operator, xml.Services.Service, journeyPattern, calendar);
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
@@ -2127,9 +2127,9 @@ namespace TransXChange.Common
                                     }
                                 }
 
-                                calendar.RunningDates = calendar.RunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.OrderBy(d => d).ToList();
+                                calendar.RunningDates = calendar.RunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.Distinct().OrderBy(d => d).ToList();
 
                                 TXCSchedule schedule = ScheduleUtils.Build(xml.Operators.Operator, xml.Services.Service, journeyPattern, calendar);
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
@@ -2670,9 +2670,9 @@ namespace TransXChange.Common
                                     }
                                 }
 
-                                calendar.RunningDates = calendar.RunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.OrderBy(d => d).ToList();
+                                calendar.RunningDates = calendar.RunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.Distinct().OrderBy(d => d).ToList();
 
                                 TXCSchedule schedule = ScheduleUtils.Build(xml.Operators.Operator, xml.Services.Service, journeyPattern, calendar);
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();
@@ -3205,9 +3205,9 @@ namespace TransXChange.Common
                                     }
                                 }
 
-                                calendar.RunningDates = calendar.RunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.OrderBy(d => d).ToList();
-                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.OrderBy(d => d).ToList();
+                                calendar.RunningDates = calendar.RunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementRunningDates = calendar.SupplementRunningDates.Distinct().OrderBy(d => d).ToList();
+                                calendar.SupplementNonRunningDates = calendar.SupplementNonRunningDates.Distinct().OrderBy(d => d).ToList();
 
                                 TXCSchedule schedule = ScheduleUtils.Build(xml.Operators.Operator, xml.Services.Service, journeyPattern, calendar);
                                 TimeSpan? arrivalTime = vehicleJourney.DepartureTime.ToTimeSpan();

--- a/TransXChange.Common/Utils/BankHolidayUtils.cs
+++ b/TransXChange.Common/Utils/BankHolidayUtils.cs
@@ -26,7 +26,7 @@ namespace TransXChange.Common.Utils
         {
             List<PublicHoliday> results = new List<PublicHoliday>();
 
-            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "New Year's Day" && h.Counties.Contains("GB-ENG")).FirstOrDefault();
+            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "New Year's Day" && h.Counties != null && h.Counties.Contains("GB-ENG")).FirstOrDefault();
 
             if (holiday != null)
             {
@@ -54,7 +54,7 @@ namespace TransXChange.Common.Utils
         {
             List<PublicHoliday> results = new List<PublicHoliday>();
 
-            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "New Year's Day" && h.Counties.Contains("GB-SCT")).LastOrDefault();
+            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "New Year's Day" && h.Counties != null && h.Counties.Contains("GB-SCT")).LastOrDefault();
 
             if (holiday != null)
             {
@@ -124,7 +124,7 @@ namespace TransXChange.Common.Utils
         {
             List<PublicHoliday> results = new List<PublicHoliday>();
 
-            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "Summer Bank Holiday" && h.Counties.Contains("GB-SCT")).FirstOrDefault();
+            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "Summer Bank Holiday" && h.Counties != null && h.Counties.Contains("GB-SCT")).FirstOrDefault();
 
             if (holiday != null)
             {
@@ -138,7 +138,7 @@ namespace TransXChange.Common.Utils
         {
             List<PublicHoliday> results = new List<PublicHoliday>();
 
-            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "Summer Bank Holiday" && h.Counties.Contains("GB-ENG")).FirstOrDefault();
+            PublicHoliday holiday = DateSystem.GetPublicHoliday(startDate, endDate, CountryCode.GB).Where(h => h.LocalName == "Summer Bank Holiday" && h.Counties != null && h.Counties.Contains("GB-ENG")).FirstOrDefault();
 
             if (holiday != null)
             {

--- a/TransXChange.England/Program.cs
+++ b/TransXChange.England/Program.cs
@@ -25,42 +25,49 @@ namespace TransXChange.England
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            GtfsHelpers gtfsHelpers = new GtfsHelpers();
-            NaptanHelpers naptanHelpers = new NaptanHelpers();
-            TravelineHelpers travelineHelpers = new TravelineHelpers();
+            try
+            {
+                GtfsHelpers gtfsHelpers = new GtfsHelpers();
+                NaptanHelpers naptanHelpers = new NaptanHelpers();
+                TravelineHelpers travelineHelpers = new TravelineHelpers();
 
-            Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
-            Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
+                Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
+                Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadEngland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
-            Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
+                Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadEngland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+                Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
-            Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
+                Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
+                Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
-            Directory.CreateDirectory(options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", options.Output));
+                Directory.CreateDirectory(options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
+                gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
+                gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
+                gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
+                gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            gtfsHelpers.WriteStops(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
+                gtfsHelpers.WriteStops(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
+                gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
+                gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(string.Format("ERROR: {0}", exception.Message));
+            }
         }
     }
 }

--- a/TransXChange.England/Program.cs
+++ b/TransXChange.England/Program.cs
@@ -25,37 +25,41 @@ namespace TransXChange.England
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            Dictionary<string, NAPTANStop> stops = NaptanHelpers.Read(options.Naptan);
+            GtfsHelpers gtfsHelpers = new GtfsHelpers();
+            NaptanHelpers naptanHelpers = new NaptanHelpers();
+            TravelineHelpers travelineHelpers = new TravelineHelpers();
+
+            Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
             Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = TravelineHelpers.ReadEngland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+            Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadEngland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = TravelineHelpers.ScanDuplicate(originals);
+            Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
             Directory.CreateDirectory(options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            GtfsHelpers.WriteAgency(originals, duplicates, options.Output);
+            gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            GtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
+            gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            GtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
+            gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            GtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
+            gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            GtfsHelpers.WriteStops(originals, duplicates, options.Output);
+            gtfsHelpers.WriteStops(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            GtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
+            gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            GtfsHelpers.WriteTrips(originals, duplicates, options.Output);
+            gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
         }
     }

--- a/TransXChange.England/Program.cs
+++ b/TransXChange.England/Program.cs
@@ -3,7 +3,7 @@ using CommandLine.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using TransXChange.Common;
+using TransXChange.Common.Helpers;
 using TransXChange.Common.Models;
 
 namespace TransXChange.England
@@ -25,37 +25,37 @@ namespace TransXChange.England
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            Dictionary<string, NAPTANStop> stops = Naptan.Read(options.Naptan);
+            Dictionary<string, NAPTANStop> stops = NaptanHelpers.Read(options.Naptan);
             Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = Traveline.ReadEngland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+            Dictionary<string, TXCSchedule> originals = TravelineHelpers.ReadEngland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = Traveline.ScanDuplicate(originals);
+            Dictionary<string, TXCSchedule> duplicates = TravelineHelpers.ScanDuplicate(originals);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
             Directory.CreateDirectory(options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            Gtfs.WriteAgency(originals, duplicates, options.Output);
+            GtfsHelpers.WriteAgency(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            Gtfs.WriteCalendar(originals, duplicates, options.Output);
+            GtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            Gtfs.WriteCalendarDates(originals, duplicates, options.Output);
+            GtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            Gtfs.WriteRoutes(originals, duplicates, options.Output);
+            GtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            Gtfs.WriteStops(originals, duplicates, options.Output);
+            GtfsHelpers.WriteStops(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            Gtfs.WriteStopTimes(originals, duplicates, options.Output);
+            GtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            Gtfs.WriteTrips(originals, duplicates, options.Output);
+            GtfsHelpers.WriteTrips(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
         }
     }

--- a/TransXChange.England/Properties/AssemblyInfo.cs
+++ b/TransXChange.England/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyCopyright("Copyright © 2020 Phil Vessey and Contributors")]
+[assembly: AssemblyCopyright("Copyright © 2021 Phil Vessey and Contributors")]
 [assembly: AssemblyTitle("TransXChange.England")]
 [assembly: AssemblyVersion("1.1.2.0")]

--- a/TransXChange.England/Properties/AssemblyInfo.cs
+++ b/TransXChange.England/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 
 [assembly: AssemblyCopyright("Copyright © 2020 Phil Vessey and Contributors")]
 [assembly: AssemblyTitle("TransXChange.England")]
-[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]

--- a/TransXChange.Scotland/Program.cs
+++ b/TransXChange.Scotland/Program.cs
@@ -3,7 +3,7 @@ using CommandLine.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using TransXChange.Common;
+using TransXChange.Common.Helpers;
 using TransXChange.Common.Models;
 
 namespace TransXChange.Scotland
@@ -25,37 +25,37 @@ namespace TransXChange.Scotland
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            Dictionary<string, NAPTANStop> stops = Naptan.Read(options.Naptan);
+            Dictionary<string, NAPTANStop> stops = NaptanHelpers.Read(options.Naptan);
             Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = Traveline.ReadScotland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+            Dictionary<string, TXCSchedule> originals = TravelineHelpers.ReadScotland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = Traveline.ScanDuplicate(originals);
+            Dictionary<string, TXCSchedule> duplicates = TravelineHelpers.ScanDuplicate(originals);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
             Directory.CreateDirectory(options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            Gtfs.WriteAgency(originals, duplicates, options.Output);
+            GtfsHelpers.WriteAgency(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            Gtfs.WriteCalendar(originals, duplicates, options.Output);
+            GtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            Gtfs.WriteCalendarDates(originals, duplicates, options.Output);
+            GtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            Gtfs.WriteRoutes(originals, duplicates, options.Output);
+            GtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            Gtfs.WriteStops(originals, duplicates, options.Output);
+            GtfsHelpers.WriteStops(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            Gtfs.WriteStopTimes(originals, duplicates, options.Output);
+            GtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            Gtfs.WriteTrips(originals, duplicates, options.Output);
+            GtfsHelpers.WriteTrips(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
         }
     }

--- a/TransXChange.Scotland/Program.cs
+++ b/TransXChange.Scotland/Program.cs
@@ -25,42 +25,49 @@ namespace TransXChange.Scotland
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            GtfsHelpers gtfsHelpers = new GtfsHelpers();
-            NaptanHelpers naptanHelpers = new NaptanHelpers();
-            TravelineHelpers travelineHelpers = new TravelineHelpers();
+            try
+            {
+                GtfsHelpers gtfsHelpers = new GtfsHelpers();
+                NaptanHelpers naptanHelpers = new NaptanHelpers();
+                TravelineHelpers travelineHelpers = new TravelineHelpers();
 
-            Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
-            Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
+                Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
+                Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadScotland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
-            Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
+                Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadScotland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+                Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
-            Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
+                Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
+                Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
-            Directory.CreateDirectory(options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", options.Output));
+                Directory.CreateDirectory(options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
+                gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
+                gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
+                gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
+                gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            gtfsHelpers.WriteStops(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
+                gtfsHelpers.WriteStops(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
+                gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
+                gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(string.Format("ERROR: {0}", exception.Message));
+            }
         }
     }
 }

--- a/TransXChange.Scotland/Program.cs
+++ b/TransXChange.Scotland/Program.cs
@@ -25,37 +25,41 @@ namespace TransXChange.Scotland
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            Dictionary<string, NAPTANStop> stops = NaptanHelpers.Read(options.Naptan);
+            GtfsHelpers gtfsHelpers = new GtfsHelpers();
+            NaptanHelpers naptanHelpers = new NaptanHelpers();
+            TravelineHelpers travelineHelpers = new TravelineHelpers();
+
+            Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
             Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = TravelineHelpers.ReadScotland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+            Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadScotland(stops, options.Traveline, options.Mode, options.Filters, options.Days);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = TravelineHelpers.ScanDuplicate(originals);
+            Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
             Directory.CreateDirectory(options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            GtfsHelpers.WriteAgency(originals, duplicates, options.Output);
+            gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            GtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
+            gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            GtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
+            gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            GtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
+            gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            GtfsHelpers.WriteStops(originals, duplicates, options.Output);
+            gtfsHelpers.WriteStops(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            GtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
+            gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            GtfsHelpers.WriteTrips(originals, duplicates, options.Output);
+            gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
         }
     }

--- a/TransXChange.Scotland/Properties/AssemblyInfo.cs
+++ b/TransXChange.Scotland/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyCopyright("Copyright © 2020 Phil Vessey and Contributors")]
+[assembly: AssemblyCopyright("Copyright © 2021 Phil Vessey and Contributors")]
 [assembly: AssemblyTitle("TransXChange.Scotland")]
 [assembly: AssemblyVersion("1.1.2.0")]

--- a/TransXChange.Scotland/Properties/AssemblyInfo.cs
+++ b/TransXChange.Scotland/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 
 [assembly: AssemblyCopyright("Copyright © 2020 Phil Vessey and Contributors")]
 [assembly: AssemblyTitle("TransXChange.Scotland")]
-[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]

--- a/TransXChange.Wales/Program.cs
+++ b/TransXChange.Wales/Program.cs
@@ -25,42 +25,49 @@ namespace TransXChange.Wales
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            GtfsHelpers gtfsHelpers = new GtfsHelpers();
-            NaptanHelpers naptanHelpers = new NaptanHelpers();
-            TravelineHelpers travelineHelpers = new TravelineHelpers();
+            try
+            {
+                GtfsHelpers gtfsHelpers = new GtfsHelpers();
+                NaptanHelpers naptanHelpers = new NaptanHelpers();
+                TravelineHelpers travelineHelpers = new TravelineHelpers();
 
-            Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
-            Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
+                Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
+                Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadWales(stops, options.Traveline, options.Mode, options.Filters, options.Days);
-            Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
+                Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadWales(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+                Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
-            Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
+                Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
+                Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
-            Directory.CreateDirectory(options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", options.Output));
+                Directory.CreateDirectory(options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
+                gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
+                gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
+                gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
+                gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            gtfsHelpers.WriteStops(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
+                gtfsHelpers.WriteStops(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
+                gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
-            Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
+                gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
+                Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(string.Format("ERROR: {0}", exception.Message));
+            }
         }
     }
 }

--- a/TransXChange.Wales/Program.cs
+++ b/TransXChange.Wales/Program.cs
@@ -25,37 +25,41 @@ namespace TransXChange.Wales
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            Dictionary<string, NAPTANStop> stops = NaptanHelpers.Read(options.Naptan);
+            GtfsHelpers gtfsHelpers = new GtfsHelpers();
+            NaptanHelpers naptanHelpers = new NaptanHelpers();
+            TravelineHelpers travelineHelpers = new TravelineHelpers();
+
+            Dictionary<string, NAPTANStop> stops = naptanHelpers.Read(options.Naptan);
             Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = TravelineHelpers.ReadWales(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+            Dictionary<string, TXCSchedule> originals = travelineHelpers.ReadWales(stops, options.Traveline, options.Mode, options.Filters, options.Days);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = TravelineHelpers.ScanDuplicate(originals);
+            Dictionary<string, TXCSchedule> duplicates = travelineHelpers.ScanDuplicate(originals);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
             Directory.CreateDirectory(options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            GtfsHelpers.WriteAgency(originals, duplicates, options.Output);
+            gtfsHelpers.WriteAgency(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            GtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
+            gtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            GtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
+            gtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            GtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
+            gtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            GtfsHelpers.WriteStops(originals, duplicates, options.Output);
+            gtfsHelpers.WriteStops(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            GtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
+            gtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            GtfsHelpers.WriteTrips(originals, duplicates, options.Output);
+            gtfsHelpers.WriteTrips(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
         }
     }

--- a/TransXChange.Wales/Program.cs
+++ b/TransXChange.Wales/Program.cs
@@ -3,7 +3,7 @@ using CommandLine.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using TransXChange.Common;
+using TransXChange.Common.Helpers;
 using TransXChange.Common.Models;
 
 namespace TransXChange.Wales
@@ -25,37 +25,37 @@ namespace TransXChange.Wales
             Console.WriteLine(CopyrightInfo.Default);
             Console.WriteLine("");
 
-            Dictionary<string, NAPTANStop> stops = Naptan.Read(options.Naptan);
+            Dictionary<string, NAPTANStop> stops = NaptanHelpers.Read(options.Naptan);
             Console.WriteLine(string.Format("READ: National Public Transport Access Nodes (NaPTAN). Found {0:#,##0.##} stops.", stops.Count));
 
-            Dictionary<string, TXCSchedule> originals = Traveline.ReadWales(stops, options.Traveline, options.Mode, options.Filters, options.Days);
+            Dictionary<string, TXCSchedule> originals = TravelineHelpers.ReadWales(stops, options.Traveline, options.Mode, options.Filters, options.Days);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} original schedules.", originals.Count));
 
-            Dictionary<string, TXCSchedule> duplicates = Traveline.ScanDuplicate(originals);
+            Dictionary<string, TXCSchedule> duplicates = TravelineHelpers.ScanDuplicate(originals);
             Console.WriteLine(string.Format("READ: Traveline National Dataset (TNDS). Found {0:#,##0.##} duplicate schedules.", duplicates.Count));
 
             Directory.CreateDirectory(options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", options.Output));
 
-            Gtfs.WriteAgency(originals, duplicates, options.Output);
+            GtfsHelpers.WriteAgency(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "agency.txt")));
 
-            Gtfs.WriteCalendar(originals, duplicates, options.Output);
+            GtfsHelpers.WriteCalendar(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar.txt")));
 
-            Gtfs.WriteCalendarDates(originals, duplicates, options.Output);
+            GtfsHelpers.WriteCalendarDates(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "calendar_dates.txt")));
 
-            Gtfs.WriteRoutes(originals, duplicates, options.Output);
+            GtfsHelpers.WriteRoutes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "routes.txt")));
 
-            Gtfs.WriteStops(originals, duplicates, options.Output);
+            GtfsHelpers.WriteStops(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stops.txt")));
 
-            Gtfs.WriteStopTimes(originals, duplicates, options.Output);
+            GtfsHelpers.WriteStopTimes(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "stop_times.txt")));
 
-            Gtfs.WriteTrips(originals, duplicates, options.Output);
+            GtfsHelpers.WriteTrips(originals, duplicates, options.Output);
             Console.WriteLine(string.Format("WRITE: {0}", Path.Combine(options.Output, "trips.txt")));
         }
     }

--- a/TransXChange.Wales/Properties/AssemblyInfo.cs
+++ b/TransXChange.Wales/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 
 [assembly: AssemblyCopyright("Copyright © 2020 Phil Vessey and Contributors")]
 [assembly: AssemblyTitle("TransXChange.Wales")]
-[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]

--- a/TransXChange.Wales/Properties/AssemblyInfo.cs
+++ b/TransXChange.Wales/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyCopyright("Copyright © 2020 Phil Vessey and Contributors")]
+[assembly: AssemblyCopyright("Copyright © 2021 Phil Vessey and Contributors")]
 [assembly: AssemblyTitle("TransXChange.Wales")]
 [assembly: AssemblyVersion("1.1.2.0")]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ stages:
 
   jobs:
   - job: Build
-    displayName: 'Build'
+    displayName: 'Build Job'
     pool:
       vmImage: '$(vmImageName)'
 
@@ -226,7 +226,7 @@ stages:
 
   jobs:
   - deployment: Deploy
-    displayName: 'Deploy'
+    displayName: 'Deploy Job'
     environment: 'development'
     pool:
       vmImage: '$(vmImageName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: '1.1.1.$(Rev:r)'
+name: '1.1.2.$(Rev:r)'
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,18 +9,18 @@ variables:
   vmImageName: 'windows-latest'
 
 stages:
-- stage: Build
-  displayName: 'Build Stage'
+- stage: 'buildSolution'
+  displayName: 'Build Solution Stage'
 
   jobs:
-  - job: Build
-    displayName: 'Build Job'
+  - job: 'buildSolution'
+    displayName: 'Build Solution Job'
     pool:
       vmImage: '$(vmImageName)'
 
     steps:
     - task: VersionAssemblies@2
-      displayName: 'Update Version'
+      displayName: 'Update Version Number'
       inputs:
         Path: '$(Build.SourcesDirectory)'
         VersionNumber: '$(Build.BuildNumber)'
@@ -28,14 +28,14 @@ stages:
         FilenamePattern: 'AssemblyInfo.*'
 
     - task: DotNetCoreCLI@2
-      displayName: 'Build Solution'
+      displayName: 'Build All Projects'
       inputs:
         command: 'build'
         projects: '**/*.csproj'
         arguments: '--configuration $(buildConfiguration)'
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish England (linux-x64)'
+      displayName: 'Publish England Project (linux-x64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.England/*.csproj'
@@ -44,7 +44,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish England (linux-arm)'
+      displayName: 'Publish England Project (linux-arm)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.England/*.csproj'
@@ -53,7 +53,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish England (linux-arm64)'
+      displayName: 'Publish England Project (linux-arm64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.England/*.csproj'
@@ -62,7 +62,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish England (win-x64)'
+      displayName: 'Publish England Project (win-x64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.England/*.csproj'
@@ -71,7 +71,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish England (win-arm)'
+      displayName: 'Publish England Project (win-arm)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.England/*.csproj'
@@ -80,7 +80,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish England (win-arm64)'
+      displayName: 'Publish England Project (win-arm64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.England/*.csproj'
@@ -89,7 +89,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Scotland (linux-x64)'
+      displayName: 'Publish Scotland Project (linux-x64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Scotland/*.csproj'
@@ -98,7 +98,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Scotland (linux-arm)'
+      displayName: 'Publish Scotland Project (linux-arm)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Scotland/*.csproj'
@@ -107,7 +107,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Scotland (linux-arm64)'
+      displayName: 'Publish Scotland Project (linux-arm64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Scotland/*.csproj'
@@ -116,7 +116,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Scotland (win-x64)'
+      displayName: 'Publish Scotland Project (win-x64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Scotland/*.csproj'
@@ -125,7 +125,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Scotland (win-arm)'
+      displayName: 'Publish Scotland Project (win-arm)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Scotland/*.csproj'
@@ -134,7 +134,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Scotland (win-arm64)'
+      displayName: 'Publish Scotland Project (win-arm64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Scotland/*.csproj'
@@ -143,7 +143,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Wales (linux-x64)'
+      displayName: 'Publish Wales Project (linux-x64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Wales/*.csproj'
@@ -152,7 +152,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Wales (linux-arm)'
+      displayName: 'Publish Wales Project (linux-arm)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Wales/*.csproj'
@@ -161,7 +161,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Wales (linux-arm64)'
+      displayName: 'Publish Wales Project (linux-arm64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Wales/*.csproj'
@@ -170,7 +170,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Wales (win-x64)'
+      displayName: 'Publish Wales Project (win-x64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Wales/*.csproj'
@@ -179,7 +179,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Wales (win-arm)'
+      displayName: 'Publish Wales Project (win-arm)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Wales/*.csproj'
@@ -188,7 +188,7 @@ stages:
         zipAfterPublish: false
 
     - task: DotNetCoreCLI@2
-      displayName: 'Publish Wales (win-arm64)'
+      displayName: 'Publish Wales Project (win-arm64)'
       inputs:
         command: 'publish'
         projects: '**/TransXChange.Wales/*.csproj'
@@ -220,13 +220,13 @@ stages:
       displayName: 'Publish Pipeline Artifact (win-arm64)'
       artifact: 'TransXChange-win-arm64'
 
-- stage: Deploy
-  displayName: 'Deploy Stage'
+- stage: 'deployPackages'
+  displayName: 'Deploy Packages Stage'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   jobs:
-  - deployment: Deploy
-    displayName: 'Deploy Job'
+  - deployment: 'deployPackages'
+    displayName: 'Deploy Packages Job'
     environment: 'development'
     pool:
       vmImage: '$(vmImageName)'


### PR DESCRIPTION
Fixed an issue which resulted in a crash when Traveline data incomplete.
Fixed an issue which resulted in a crash when checking public holidays.
Fixed an issue which resulted in duplicate running dates.
Fixed an issue which resulted in a crash when running in parallel.
Fixed an issue which resulted in a crash when scanning for duplicates.